### PR TITLE
E2e passes

### DIFF
--- a/cmd/evict/main.go
+++ b/cmd/evict/main.go
@@ -73,6 +73,7 @@ func main() {
 		}
 
 	} else if *node != "" {
+		var podsmeta []v1.ObjectMeta
 		namespaces, err := clientset.CoreV1().Namespaces().List(ctx, v1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
@@ -117,7 +118,7 @@ func main() {
 			defer wg.Done()
 
 			for ctx.Err() == nil {
-				err = clientset.PolicyV1().Evictions(*namespace).Evict(ctx, &policy.Eviction{
+				err = clientset.PolicyV1().Evictions(meta.Namespace).Evict(ctx, &policy.Eviction{
 					ObjectMeta: meta,
 				})
 				if err == nil {

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,13 @@
 # Adds namespace to all resources.
-namespace: k8s-pdb-autoscaler-system
+namespace: k8s-pdb-autoscaler
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: k8s-pdb-autoscaler-
+#using this breaks the pdbwatcher targetName
+#namePrefix: k8s-pdb-autoscaler-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
+#- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -43,8 +43,7 @@ resources:
   # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
   # +kubebuilder:scaffold:defaultkustomizecainjectionpatch
 
-configurations:
-  - kustomizeconfig.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
 #replacements:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: example.com/k8s-pdb-autoscaler
-  newTag: v0.0.1
+  newName: paulgmiller/k8s-pdb-autoscaler
+  newTag: latest

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,50 +17,77 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/pkg/apis/policy"
 
 	"github.com/paulgmiller/k8s-pdb-autoscaler/test/utils"
 )
 
 const namespace = "k8s-pdb-autoscaler-system"
+const kindClusterName = "kind-kind-e2e"
+
+var cleanEnv = true
 
 var _ = Describe("controller", Ordered, func() {
 	BeforeAll(func() {
-		By("installing prometheus operator")
-		Expect(utils.InstallPrometheusOperator()).To(Succeed())
+		//allow to bypass if they ahve one?
+		if cleanEnv {
+			By("creating kind cluster")
+			cmd := exec.Command("kind", "create", "cluster", "--config", "test/e2e/kind.yaml", "--name", kindClusterName)
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Print(string(output))
 
-		By("installing the cert-manager")
-		Expect(utils.InstallCertManager()).To(Succeed())
+			cmd = exec.Command("kubectl", "config", "use-context", "--config", "test/e2e/kind.yaml", "--name", kindClusterName)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, _ = utils.Run(cmd)
+			//By("installing prometheus operator")
+			//Expect(utils.InstallPrometheusOperator()).To(Succeed())
+
+			//By("installing the cert-manager")
+			//Expect(utils.InstallCertManager()).To(Succeed())
+			By("creating manager namespace")
+			_, err = utils.Run(exec.Command("kubectl", "create", "ns", namespace))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 	})
 
 	AfterAll(func() {
-		By("uninstalling the Prometheus manager bundle")
-		utils.UninstallPrometheusOperator()
+		//By("uninstalling the Prometheus manager bundle")
+		//utils.UninstallPrometheusOperator()
 
-		By("uninstalling the cert-manager bundle")
-		utils.UninstallCertManager()
+		//By("uninstalling the cert-manager bundle")
+		//utils.UninstallCertManager()
+		if cleanEnv {
 
-		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
+			By("removing manager namespace")
+			cmd := exec.Command("kind", "delete", "cluster", "-n", "kind")
+			_, _ = utils.Run(cmd)
+		}
 	})
 
 	Context("Operator", func() {
+		ctx := context.Background()
 		It("should run successfully", func() {
 			var controllerPodName string
 			var err error
 
 			// projectimage stores the name of the image used in the example
-			var projectimage = "example.com/k8s-pdb-autoscaler:v0.0.1"
+			var projectimage = "paulgmiller/k8s-pdb-autoscaler:latest"
 
 			By("building the manager(Operator) image")
 			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
@@ -68,7 +95,7 @@ var _ = Describe("controller", Ordered, func() {
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("loading the the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectimage)
+			err = utils.LoadImageToKindClusterWithName(projectimage, kindClusterName)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("installing CRDs")
@@ -81,42 +108,62 @@ var _ = Describe("controller", Ordered, func() {
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			// create the clientset
+			clientset, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("validating that the controller-manager pod is running as expected")
+			var nodeName string
 			verifyControllerUp := func() error {
 				// Get pod name
 
-				cmd = exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
-
-				podOutput, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				podNames := utils.GetNonEmptyLines(string(podOutput))
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
+				pods, err := clientset.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{LabelSelector: "control-plane=controller-manager", Limit: 1})
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				if len(pods.Items) != 1 {
+					return fmt.Errorf("got %d controller pods", len(pods.Items))
 				}
-				controllerPodName = podNames[0]
-				ExpectWithOffset(2, controllerPodName).Should(ContainSubstring("controller-manager"))
-
-				// Validate pod status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if string(status) != "Running" {
-					return fmt.Errorf("controller pod in %s status", status)
+				if pods.Items[0].Status.Phase != "Running" {
+					return fmt.Errorf("controller pod in %s status", pods.Items[0].Status.Phase)
 				}
+				nodeName = pods.Items[0].Spec.NodeName
 				return nil
 			}
 			EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
 
+			// Cordon and drain the node that the controller-manager pod is running on
+			node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			_, err = clientset.CoreV1().Nodes().Update(ctx, node, v1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			drain := func() error {
+				var podsmeta []v1.ObjectMeta
+				namespaces, err := clientset.CoreV1().Namespaces().List(ctx, v1.ListOptions{})
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				for _, ns := range namespaces.Items {
+					pods, err := clientset.CoreV1().Pods(ns.Name).List(ctx, v1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName})
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+					for _, p := range pods.Items {
+						podsmeta = append(podsmeta, p.ObjectMeta)
+					}
+				}
+				//todo parallize so
+				for _, meta := range podsmeta {
+					err = clientset.PolicyV1().Evictions(meta.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: meta,
+					})
+					if errors.IsTooManyRequests(err) {
+						return fmt.Errorf("failed to evict %s/%s: %v", meta.Namespace, meta.Name, err)
+					}
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, drain, time.Minute, time.Second).Should(Succeed())
+
+			//what else make sure we scale back down?
 		})
 	})
 })

--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -1,0 +1,6 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -104,11 +104,7 @@ func InstallCertManager() error {
 }
 
 // LoadImageToKindCluster loads a local docker image to the kind cluster
-func LoadImageToKindClusterWithName(name string) error {
-	cluster := "kind"
-	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
-		cluster = v
-	}
+func LoadImageToKindClusterWithName(name, cluster string) error {
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
 	cmd := exec.Command("kind", kindOptions...)
 	_, err := Run(cmd)


### PR DESCRIPTION
The e2e:
* creates a kind cluster (can disable)
* deploys (using make deploy kustomize we'll see if we stick with that
* checks controller manger pod gets to ready
* cordons the node the pod is on and drains
* ensures the deloyment scales back down.

Try it out using make test-e2e

Addresses most of issue #12 