### PR TITLE
fix roles, tune errors and logging

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,15 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets
   verbs:
   - get

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -35,7 +35,6 @@ func (r *DeploymentToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Fetch the Deployment instance
 	var deployment v1.Deployment
 	if err := r.Get(ctx, req.NamespacedName, &deployment); err != nil {
-		log.Error(err, "unable to fetch Deployment")
 		if apierrors.IsNotFound(err) {
 			e := r.handleDeploymentDeletion(ctx, req)
 			return ctrl.Result{}, client.IgnoreNotFound(e)
@@ -85,11 +84,10 @@ func (r *DeploymentToPDBReconciler) handleDeploymentReconcile(ctx context.Contex
 		},
 	}
 
-	log.Info("Creating PodDisruptionBudget", "namespace", pdb.Namespace, "name", pdb.Name)
 	if err := r.Create(ctx, pdb); err != nil {
-		log.Error(err, "unable to create PDB")
 		return reconcile.Result{}, err
 	}
+	log.Info("Created PodDisruptionBudget", "namespace", pdb.Namespace, "name", pdb.Name)
 
 	return reconcile.Result{}, nil
 }
@@ -102,30 +100,11 @@ func (r *DeploymentToPDBReconciler) generatePDBName(deploymentName string) strin
 // we can leak here if controller stops working
 // Ironically leaking pdbs would block our current upgrade logic we had to toggle off wher expected pods == 0
 func (r *DeploymentToPDBReconciler) handleDeploymentDeletion(ctx context.Context, req ctrl.Request) error {
-	log := log.FromContext(ctx)
-
-	// Try to get the associated PDB
-	pdb := &policyv1.PodDisruptionBudget{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.NamespacedName.Namespace,
-		Name:      r.generatePDBName(req.NamespacedName.Name),
-	}, pdb)
-	//ToDo: use pdb.DeletionTimestamp instead to determine if pdb got deleted
-	if err != nil {
-		// If there's no PDB or it can't be fetched, just return
-		log.Info("PodDisruptionBudget does not exist or error fetching", "namespace", req.NamespacedName.Namespace, "name", req.NamespacedName.Name)
-		return err
-	}
-
+	pdb := &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: r.generatePDBName(req.Name), Namespace: req.Namespace}}
 	// ToDo: only delete if it has createdby/ownerref
 	// If the PDB exists, delete it
-	log.Info("Deleting PodDisruptionBudget", "namespace", pdb.Namespace, "name", pdb.Name)
-	if err := r.Delete(ctx, pdb); err != nil {
-		log.Error(err, "unable to delete PDB")
-		return err
-	}
-
-	return nil
+	log.FromContext(ctx).Info("Deleting PodDisruptionBudget", "namespace", pdb.Namespace, "name", pdb.Name)
+	return r.Delete(ctx, pdb)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -147,6 +147,6 @@ func (r *DeploymentToPDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 			},
 		}).
-		//Owns(&policyv1.PodDisruptionBudget{}). // Watch PDBs for ownership
+		Owns(&policyv1.PodDisruptionBudget{}). // Watch PDBs for ownership
 		Complete(r)
 }

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -136,21 +136,6 @@ func (r *DeploymentToPDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Deployment{}).
 		WithEventFilter(predicate.Funcs{
-			// Only trigger for Create and Delete events
-			CreateFunc: func(e event.CreateEvent) bool {
-				logger.Info("Create event detected, pdb will be created if not exists")
-				// Handle create event (this will be true for all create events)
-				//creationTime, _ := time.Parse(time.RFC3339, e.Object.GetCreationTimestamp().String())
-				//if time.Since(creationTime) < 5*time.Minute {
-				//	return false // Ignore create if it's an existing resource (e.g., by checking timestamp)
-				//}
-				return true // Allow to create for new resources
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				logger.Info("Delete event detected, pdb will be deleted if exists")
-				// Handle delete event (this will be true for all delete events)
-				return true
-			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				logger.Info("Update event detected, no action will be taken")
 				// No need to handle update event
@@ -162,6 +147,6 @@ func (r *DeploymentToPDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 			},
 		}).
-		Owns(&policyv1.PodDisruptionBudget{}). // Watch PDBs for ownership
+		//Owns(&policyv1.PodDisruptionBudget{}). // Watch PDBs for ownership
 		Complete(r)
 }

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -48,12 +48,9 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 		return ctrl.Result{}, err // Error fetching PDBWatcher
 	}
-	node = node.DeepCopy() //don't mutate the cache
-	logger.Info("Reconciling node", "name", node.Name, "unschedulable", node.Spec.Unschedulable)
 
 	if !node.Spec.Unschedulable {
 		return ctrl.Result{}, err
-
 	}
 	var podlist corev1.PodList
 	if err := r.List(ctx, &podlist, client.MatchingFields{NodeNameIndex: node.Name}); err != nil {
@@ -103,7 +100,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			continue
 		}
 
-		logger.Info("Found pdbwatcher for pod", "name", applicablePDBWatcher.Name, "namespace", pod.Namespace, "podname", pod.Name)
+		logger.Info("Found pdbwatcher for pod", "name", applicablePDBWatcher.Name, "namespace", pod.Namespace, "podname", pod.Name, "node", node.Name)
 		pod := pod.DeepCopy()
 		updatedpod := podutil.UpdatePodCondition(&pod.Status, &v1.PodCondition{
 			Type:    v1.DisruptionTarget,

--- a/internal/controller/pdb_to_pdbwatcher_controller.go
+++ b/internal/controller/pdb_to_pdbwatcher_controller.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8s_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,38 +29,39 @@ type PDBToPDBWatcherReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;create;watch
+// +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;update;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;update;watch
 
 // Reconcile reads the state of the cluster for a PDB and creates/deletes PDBWatchers accordingly.
 func (r *PDBToPDBWatcherReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := log.FromContext(ctx)
 	// Fetch the PodDisruptionBudget object based on the reconcile request
 	var pdb policyv1.PodDisruptionBudget
 	err := r.Get(ctx, req.NamespacedName, &pdb)
-	if apierrors.IsNotFound(err) {
-		// If the PDB is deleted, we should delete the corresponding PDBWatcher.
-		// First, check if the PDBWatcher exists
-		var pdbWatcher types.PDBWatcher
-		err := r.Get(ctx, req.NamespacedName, &pdbWatcher)
-		if err == nil {
-			// Delete PDBWatcher if PDB is deleted
-			// possibility of a leak here if controller stops working...
-			// and also we're not using finalizers/ownerrefs yet
-			err := r.Delete(ctx, &pdbWatcher)
-			if err != nil {
-				return reconcile.Result{}, fmt.Errorf("unable to delete PDBWatcher: %v", err)
-			}
-			log.Log.Info("Deleted PDBWatcher", "name", req.NamespacedName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			err := r.Delete(ctx, &types.PDBWatcher{ObjectMeta: metav1.ObjectMeta{Name: req.Name, Namespace: req.Namespace}})
+			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	}
 
 	// If the PDB exists, create a corresponding PDBWatcher if it does not exist
 	var pdbWatcher types.PDBWatcher
 	err = r.Get(ctx, req.NamespacedName, &pdbWatcher)
-
-	if apierrors.IsNotFound(err) {
-		deploymentName, e := r.discoverDeployment(ctx, &pdb)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+
+		log.Info("Found: ", "pdb", pdb.Name, "namespace", pdb.Namespace)
+
+		deploymentName, e := r.discoverDeployment(ctx, &pdb)
+		if e != nil {
 			return reconcile.Result{}, e
+		}
+		if deploymentName == "" { //ther was no owning deployment don't autocreate. Better sentinal value?
+			return reconcile.Result{}, nil
 		}
 
 		// Create a new PDBWatcher
@@ -86,11 +86,10 @@ func (r *PDBToPDBWatcherReconciler) Reconcile(ctx context.Context, req reconcile
 
 		err := r.Create(ctx, &pdbWatcher)
 		if err != nil {
+			log.Info("Created PDBWatcher", "name", pdb.Name)
 			return reconcile.Result{}, fmt.Errorf("unable to create PDBWatcher: %v", err)
 		}
-		log.Log.Info("Created PDBWatcher", "name", pdb.Name)
 	}
-
 	// Return no error and no requeue
 	return reconcile.Result{}, nil
 }
@@ -102,15 +101,6 @@ func (r *PDBToPDBWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&policyv1.PodDisruptionBudget{}).
 		WithEventFilter(predicate.Funcs{
 			// Only trigger for Create and Delete events
-			CreateFunc: func(e event.CreateEvent) bool {
-				// Handle create event (this will be true for all create events)
-				//should we create pdbwatchers for customer created pdbs
-				return true
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				// Handle delete event (this will be true for all delete events)
-				return true
-			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				//ToDo: theoretically you could have a pdb update and change
 				// its label selectors in which case you might need to update the deployment target?
@@ -165,13 +155,7 @@ func (r *PDBToPDBWatcherReconciler) discoverDeployment(ctx context.Context, pdb 
 						return rsOwnerRef.Name, nil
 					}
 				}
-				// If we get here, the ReplicaSet doesn't have a Deployment owner reference
-				// So we return a 'NotFound' error for Deployment not found
-				return "", apierrors.NewNotFound(
-					schema.GroupResource{Group: "apps", Resource: "deployments"},
-					ownerRef.Name,
-				)
-
+				// no replicaset owner just move on and see if any other pods have have something.
 			}
 			//// Optional: Handle StatefulSets if necessary
 			//if ownerRef.Kind == "StatefulSet" {
@@ -183,8 +167,9 @@ func (r *PDBToPDBWatcherReconciler) discoverDeployment(ctx context.Context, pdb 
 			//	logger.Info("Found StatefulSet owner", "statefulSet", statefulSet.Name)
 			//	// Handle StatefulSet logic if required
 			//}
+
 		}
 	}
 
-	return "", fmt.Errorf("PDB %s/%s overlaps with zero deployments", pdb.Namespace, pdb.Name)
+	return "", nil
 }

--- a/internal/controller/pdb_to_pdbwatcher_controller.go
+++ b/internal/controller/pdb_to_pdbwatcher_controller.go
@@ -86,9 +86,9 @@ func (r *PDBToPDBWatcherReconciler) Reconcile(ctx context.Context, req reconcile
 
 		err := r.Create(ctx, &pdbWatcher)
 		if err != nil {
-			log.Info("Created PDBWatcher", "name", pdb.Name)
 			return reconcile.Result{}, fmt.Errorf("unable to create PDBWatcher: %v", err)
 		}
+		log.Info("Created PDBWatcher", "name", pdb.Name)
 	}
 	// Return no error and no requeue
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Need replicaset permission for discover deployment.

Two things with errors 
1) always handle errors not just not found
2) discover deployment should have its own notfound becasue its not an apiserver not found

Just delete rather than get/delete

and logging should be just when we do something. Controller runtime automatically logs errors