### PR TITLE
don't create pdb if one already matches

### DIFF
--- a/internal/controller/deployment_to_pdb_controller_test.go
+++ b/internal/controller/deployment_to_pdb_controller_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("DeploymentToPDBReconciler", func() {
-	const namespace = "test"
+	var namespace string
 	const deploymentName = "example-deployment"
 
 	var (
@@ -25,15 +25,15 @@ var _ = Describe("DeploymentToPDBReconciler", func() {
 	)
 
 	BeforeEach(func() {
-		// Create the Namespace object (from corev1)
 		namespaceObj := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
+				GenerateName: "test",
 			},
 		}
 
 		// create the namespace using the controller-runtime client
-		_ = k8sClient.Create(context.Background(), namespaceObj)
+		Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
+		namespace = namespaceObj.Name
 
 		// Create a fake clientset and add required schemas
 		s := scheme.Scheme
@@ -84,20 +84,11 @@ var _ = Describe("DeploymentToPDBReconciler", func() {
 		}
 
 		// Create the deployment
-		_ = r.Client.Create(context.Background(), deployment)
-		//Expect(err).To(BeNil())
+		err := r.Client.Create(context.Background(), deployment)
+		Expect(err).To(BeNil())
 	})
 
 	AfterEach(func() {
-		// Create the PDB with a deletion timestamp set
-		pdb := &policyv1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      deploymentName,
-				Namespace: namespace,
-			},
-		}
-		_ = r.Client.Delete(context.Background(), pdb)
-		//Expect(err).To(BeNil())
 
 	})
 
@@ -160,7 +151,7 @@ var _ = Describe("DeploymentToPDBReconciler", func() {
 			// Create the PDB first
 			pdb := &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      deploymentName,
+					Name:      "someothername",
 					Namespace: namespace,
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{

--- a/internal/controller/deployment_to_pdb_controller_test.go
+++ b/internal/controller/deployment_to_pdb_controller_test.go
@@ -88,8 +88,7 @@ var _ = Describe("DeploymentToPDBReconciler", func() {
 		}
 
 		// Create the deployment
-		err := r.Client.Create(ctx, deployment)
-		Expect(err).To(BeNil())
+		Expect(r.Client.Create(ctx, deployment)).To(Succeed())
 	})
 
 	Describe("when a deployment is created", func() {

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -66,7 +66,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		//}
 
 		pdbWatcherList := &pdbautoscaler.PDBWatcherList{}
-		err = r.Client.List(ctx, pdbWatcherList, &client.ListOptions{Namespace: req.Namespace})
+		err = r.Client.List(ctx, pdbWatcherList, &client.ListOptions{Namespace: pod.Namespace})
 		if err != nil {
 			logger.Error(err, "Error: Unable to list PDBWatchers")
 			return ctrl.Result{}, err
@@ -93,7 +93,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 			if selector.Matches(labels.Set(pod.Labels)) {
 				applicablePDBWatcher = pdbWatcher.DeepCopy()
-				break
+				break //should we keep going to ensure multiple pdbwatchers don't match?
 			}
 		}
 		if applicablePDBWatcher == nil {

--- a/internal/controller/node_reconciler_test.go
+++ b/internal/controller/node_reconciler_test.go
@@ -213,7 +213,3 @@ var _ = Describe("Node Controller", func() {
 		})
 	})
 })
-
-func int64Ptr(i int64) *int64 {
-	return &i
-}

--- a/internal/controller/node_reconciler_test.go
+++ b/internal/controller/node_reconciler_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Node Controller", func() {
 	var typeNamespacedName, podNamespacedName types.NamespacedName
 	nodeNamespacedName := types.NamespacedName{Name: nodeName}
 
-	Context("When reconciling a resource", func() {
+	Context("When reconciling a node resource", func() {
 
 		BeforeEach(func() {
 			namespaceObj := &corev1.Namespace{
@@ -40,7 +40,7 @@ var _ = Describe("Node Controller", func() {
 			}
 
 			// create the namespace using the controller-runtime client
-			Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
+			Expect(k8sClient.Create(ctx, namespaceObj)).To(Succeed())
 			namespace = namespaceObj.Name
 			typeNamespacedName = types.NamespacedName{Name: resourceName, Namespace: namespace}
 			podNamespacedName = types.NamespacedName{Name: podName, Namespace: namespace}

--- a/internal/controller/pdb_to_pdbwatcher_controller_test.go
+++ b/internal/controller/pdb_to_pdbwatcher_controller_test.go
@@ -172,9 +172,6 @@ var _ = Describe("PDBToPDBWatcherReconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-	})
-
 	Context("When the PDB exists", func() {
 		It("should create a PDBWatcher if it doesn't already exist", func() {
 			// Prepare a PodDisruptionBudget in the "test" namespace

--- a/internal/controller/pdbwatcher_controller_test.go
+++ b/internal/controller/pdbwatcher_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("PDBWatcher Controller", func() {
 			}
 
 			// create the namespace using the controller-runtime client
-			Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
+			Expect(k8sClient.Create(ctx, namespaceObj)).To(Succeed())
 			namespace = namespaceObj.Name
 			typeNamespacedName = types.NamespacedName{Name: resourceName, Namespace: namespace}
 			deploymentNamespacedName = types.NamespacedName{Name: deploymentName, Namespace: namespace}
@@ -438,7 +438,7 @@ var _ = Describe("PDBWatcher Controller", func() {
 			}
 
 			// create the namespace using the controller-runtime client
-			Expect(k8sClient.Create(context.Background(), namespaceObj)).To(Succeed())
+			Expect(k8sClient.Create(ctx, namespaceObj)).To(Succeed())
 			namespace = namespaceObj.Name
 			typeNamespacedName = types.NamespacedName{Name: resourceName, Namespace: namespace}
 		})


### PR DESCRIPTION
This also adds a test and refactors tests to
1) use a generated namespace and ignore cleanip except for node
2) don;'t use as much context.Background diretly)
3) always check client errors in test. 